### PR TITLE
Trying to fix windows with ocaml cygwin stuff

### DIFF
--- a/dypgen.install
+++ b/dypgen.install
@@ -1,0 +1,5 @@
+bin: [
+  "dypgen/dypgen.opt"
+  "dypgen/dypgen"
+  "dyp2gram.pl" {"dyp2gram"}
+]

--- a/grain_dypgen.opam
+++ b/grain_dypgen.opam
@@ -10,11 +10,9 @@ depends: [
 ]
 patches: ["install-bsd-compatible.patch"]
 install: [
-  make
-  "install"
-  "DYPGENLIBDIR=%{lib}%"
-  "BINDIR=%{bin}%"
-  "MANDIR=%{man}%/man1"
+  [make "install" "DYPGENLIBDIR=%{lib}%" "BINDIR=%{bin}%" "MANDIR=%{man}%/man1"]
+  ["sh.exe" "-c" "if [ -f '%{bin}%/dypgen' ] && [ ! -f '%{bin}%/dypgen.exe' ] ; then mv '%{bin}%/dypgen' '%{bin}%/dypgen.exe' ; fi" ] { os = "win32" }
+  ["sh.exe" "-c" "if [ -f '%{bin}%/dypgen.opt' ] && [ ! -f '%{bin}%/dypgen.opt.exe' ] ; then mv '%{bin}%/dypgen.opt' '%{bin}%/dypgen.opt.exe' ; fi" ] { os = "win32" }
 ]
 synopsis: "Self-extensible parsers and lexers for OCaml"
 description: """

--- a/install-bsd-compatible.patch
+++ b/install-bsd-compatible.patch
@@ -1,0 +1,62 @@
+--- dypgen.20120619-1/Makefile.orig	2013-04-02 16:17:00.000000000 +0200
++++ dypgen.20120619-1/Makefile	2013-04-02 16:21:59.000000000 +0200
+@@ -22,20 +22,24 @@
+ 
+ #install with ocaml-findlib
+ install: install_opt
+-	install -D --mode=755 dypgen/dypgen $(BINDIR)
+-	install -D --mode=755 dyp2gram.pl $(BINDIR)/dyp2gram
+-	install -D --mode=644 doc/dypgen.1 $(MANDIR)/dypgen.1
+-	install -D --mode=644 doc/dypgen.1 $(MANDIR)/dypgen.opt.1
+-	install -D --mode=644 doc/dypgen.1 $(MANDIR)/dyp2gram.1
++	install -d $(BINDIR)
++	install -m 755 dypgen/dypgen $(BINDIR)
++	install -m 755 dyp2gram.pl $(BINDIR)/dyp2gram
++	install -d $(MANDIR)
++	install -m 644 doc/dypgen.1 $(MANDIR)/dypgen.1
++	install -m 644 doc/dypgen.1 $(MANDIR)/dypgen.opt.1
++	install -m 644 doc/dypgen.1 $(MANDIR)/dyp2gram.1
+ 	cd dyplib; $(MAKE) install
+ 
+ #install without ocaml-findlib
+ install2: install_opt
+-	install -D --mode=755 dypgen/dypgen $(BINDIR)
+-	install -D --mode=755 dyp2gram.pl $(BINDIR)/dyp2gram
+-	install -D --mode=644 doc/dypgen.1 $(MANDIR)/dypgen.1
+-	install -D --mode=644 doc/dypgen.1 $(MANDIR)/dypgen.opt.1
+-	install -D --mode=644 doc/dypgen.1 $(MANDIR)/dyp2gram.1
++	install -d $(BINDIR)
++	install -m 755 dypgen/dypgen $(BINDIR)
++	install -m 755 dyp2gram.pl $(BINDIR)/dyp2gram
++	install -d $(MANDIR)
++	install -m 644 doc/dypgen.1 $(MANDIR)/dypgen.1
++	install -m 644 doc/dypgen.1 $(MANDIR)/dypgen.opt.1
++	install -m 644 doc/dypgen.1 $(MANDIR)/dyp2gram.1
+ 	cd dyplib; $(MAKE) install2
+ 
+ ifdef CAMLOPT
+--- dypgen.20120619-1/dyplib/Makefile.orig	2013-04-02 16:15:48.000000000 +0200
++++ dypgen.20120619-1/dyplib/Makefile	2013-04-02 16:16:41.000000000 +0200
+@@ -28,15 +28,18 @@
+ 	- $(OCAMLFIND) remove -destdir $(DYPGENLIBDIR) dyp
+ 
+ install2: install_dyp install_opt
+-	install -D --mode=644 dyp.cmi $(DYPGENLIBDIR)/dyp
++	install -d $(DYPGENLIBDIR)/dyp
++	install -m 644 dyp.cmi $(DYPGENLIBDIR)/dyp
+ 
+ install_dyp:
+-	install -D --mode=644 dyp.cma $(DYPGENLIBDIR)/dyp
++	install -d $(DYPGENLIBDIR)/dyp
++	install -m 644 dyp.cma $(DYPGENLIBDIR)/dyp
+ 
+ ifdef CAMLOPT
+ install_opt:
+-	install -D --mode=644 dyp.cmxa $(DYPGENLIBDIR)/dyp
+-	install -D --mode=644 dyp.a $(DYPGENLIBDIR)/dyp
++	install -d $(DYPGENLIBDIR)/dyp
++	install -m 644 dyp.cmxa $(DYPGENLIBDIR)/dyp
++	install -m 644 dyp.a $(DYPGENLIBDIR)/dyp
+ else
+ install_opt:
+ endif


### PR DESCRIPTION
I basically copied the code from https://github.com/fdopen/opam-repository-mingw/tree/opam2/packages/dypgen/dypgen.20120619-1, which seem to have been partially migrated to here but the patches were missing when I tried to install it from source.

I added those back in and added the Windows build scripts from that other project. It seems to build on Windows CI now.